### PR TITLE
機能（レベル1）

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -35,7 +35,7 @@ class WebhookController < ApplicationController
           tf.write(response.body)
         when Line::Bot::Event::MessageType::Location
           title = event.message['title']
-          address = event.message['address']
+          address = event.message['address'].gsub(/日本、|〒\d{3}-\d{4}/, '')
           now_location = title || address + '付近'
           message = {
             type: 'text',


### PR DESCRIPTION
地名が存在しない場合には住所を返すようにしていますが、住所が冗長だったため「日本、」という文字列および郵便番号を除去するように変更しました。
レベル1の機能として想定していたものは全て実装できました。