### PR TITLE
【WIP】Tokyo乗り換えAPIテスト

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -24,9 +24,13 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
+          text = event.message['text'].split("\n")
+          route_service = RouteInTokyoService.new
+          route = route_service.get_route_in_tokyo(text[0], text[1])
+          output = route_service.get_route_detail(route)
           message = {
             type: 'text',
-            text: event.message['text']
+            text: output
           }
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video

--- a/app/services/route_in_tokyo_service.rb
+++ b/app/services/route_in_tokyo_service.rb
@@ -1,0 +1,40 @@
+require 'net/http'
+require 'uri'
+require 'json'
+require 'pp'
+
+class RouteInTokyoService
+
+	def get_src_station(each_route)
+		return each_route["src_station"]["station_name"]
+	end
+
+	def get_dst_station(each_route)
+		return each_route["dst_station"]["station_name"]
+	end
+	
+	def get_line(each_route)
+		return each_route["line"]["line_name"]
+	end
+
+	def get_route_in_tokyo(src, dst)
+		path = URI.escape("https://api.trip2.jp/ex/tokyo/v1.0/json?src=#{src}&dst=#{dst}&key=キー")
+		uri = URI.parse(path)
+		json = Net::HTTP.get(uri)
+		#result = JSON.pretty_generate(JSON.parse(json))
+		result = JSON.parse(json)
+		return result
+	end
+
+	def get_route_detail(route)
+		result = ""
+		route["ways"].each{|value|
+			src = get_src_station(value)
+			dst = get_dst_station(value)
+			line = get_line(value)
+			result += "#{src} -> #{dst} (#{line}) "
+		}
+		return result
+	end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,7 @@ module RubyGettingStarted
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    config.autoload_paths << "#{Rails.root}/app/services"
   end
 end


### PR DESCRIPTION
Tokyo乗り換えAPIを叩くことで経路を返してくれるようにしました。
現在、駅名を改行込みで2つ入力するようになっていますが、存在しない駅名を入れたり
駅名が2つでなかった場合などの処理を一切行っていないため今後修正していく予定です。
また、経路の表示もかなり雑で、最後に余分なスペースが入っています。

【入力例】
馬込
国際展示場

【出力例】
馬込 -> 中延 (都営浅草線) 中延 -> 大井町 (東急大井町線) 大井町 -> 国際展示場 (りんかい線) 